### PR TITLE
feat: harden client api-key access using customer secret

### DIFF
--- a/apps/client/src/app/hooks/user/useUser.tsx
+++ b/apps/client/src/app/hooks/user/useUser.tsx
@@ -155,7 +155,7 @@ async function loadUser(
     const res = await apiGateway.getUser(payload.email);
     user = res.data.user;
     if (user) {
-      await stiggClient.setCustomerId(user.stiggCustomerId, res.data.stiggCustomerSecret);
+      await stiggClient.setCustomerId(user.stiggCustomerId, res.data.stiggCustomerToken);
       stiggCustomer = await stiggClient.getCustomer();
     }
   }

--- a/apps/client/src/app/hooks/user/useUser.tsx
+++ b/apps/client/src/app/hooks/user/useUser.tsx
@@ -155,7 +155,7 @@ async function loadUser(
     const res = await apiGateway.getUser(payload.email);
     user = res.data.user;
     if (user) {
-      await stiggClient.setCustomerId(user.stiggCustomerId);
+      await stiggClient.setCustomerId(user.stiggCustomerId, res.data.stiggCustomerSecret);
       stiggCustomer = await stiggClient.getCustomer();
     }
   }

--- a/apps/server/src/app/stiggClient.ts
+++ b/apps/server/src/app/stiggClient.ts
@@ -20,14 +20,16 @@ export function initStiggClient(): Stigg {
   return stiggClient;
 }
 
-export function createCustomerSecret(customerId: string): string | null {
+export function createCustomerToken(customerId: string): string | null {
   const signingToken = process.env['NX_STIGG_SIGNING_TOKEN'];
 
   if (!signingToken) {
     return null;
   }
 
-  return createHmac('sha256', signingToken).update(customerId).digest('hex');
+  const signature = createHmac('sha256', signingToken).update(customerId).digest('hex');
+
+  return `HMAC-SHA256 ${customerId}:${signature}`;
 }
 
 export const STARTER_PLAN_ID = 'plan-todos-starter';

--- a/apps/server/src/app/stiggClient.ts
+++ b/apps/server/src/app/stiggClient.ts
@@ -1,4 +1,5 @@
 import Stigg from '@stigg/node-server-sdk';
+import { createHmac } from 'crypto';
 
 export let stiggClient: Stigg;
 
@@ -17,6 +18,16 @@ export function initStiggClient(): Stigg {
   stiggClient = Stigg.initialize({ apiKey });
 
   return stiggClient;
+}
+
+export function createCustomerSecret(customerId: string): string | null {
+  const signingToken = process.env['NX_STIGG_SIGNING_TOKEN'];
+
+  if (!signingToken) {
+    return null;
+  }
+
+  return createHmac('sha256', signingToken).update(customerId).digest('hex');
 }
 
 export const STARTER_PLAN_ID = 'plan-todos-starter';

--- a/apps/server/src/app/users/users-router.ts
+++ b/apps/server/src/app/users/users-router.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import * as shortUUID from 'short-uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
-import { stiggClient, ENTITLEMENTS_IDS, STARTER_PLAN_ID, createCustomerSecret } from '../stiggClient';
+import { stiggClient, ENTITLEMENTS_IDS, STARTER_PLAN_ID, createCustomerToken } from '../stiggClient';
 import * as usersRepository from './users-repository';
 
 const router = express.Router();
@@ -11,9 +11,9 @@ router.get('/:email', async (req, res) => {
   const { email } = req.params;
 
   const user = await usersRepository.getUserByEmail(email);
-  const stiggCustomerSecret = user ? createCustomerSecret(user.stiggCustomerId) : null;
+  const stiggCustomerToken = user ? createCustomerToken(user.stiggCustomerId) : null;
 
-  res.json({ user, stiggCustomerSecret });
+  res.json({ user, stiggCustomerToken });
 });
 
 router.post('/login', async (req, res) => {

--- a/apps/server/src/app/users/users-router.ts
+++ b/apps/server/src/app/users/users-router.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import * as shortUUID from 'short-uuid';
 import { authMiddleware } from '../middleware/authMiddleware';
-import { stiggClient, ENTITLEMENTS_IDS, STARTER_PLAN_ID } from '../stiggClient';
+import { stiggClient, ENTITLEMENTS_IDS, STARTER_PLAN_ID, createCustomerSecret } from '../stiggClient';
 import * as usersRepository from './users-repository';
 
 const router = express.Router();
@@ -11,8 +11,9 @@ router.get('/:email', async (req, res) => {
   const { email } = req.params;
 
   const user = await usersRepository.getUserByEmail(email);
+  const stiggCustomerSecret = user ? createCustomerSecret(user.stiggCustomerId) : null;
 
-  res.json({ user });
+  res.json({ user, stiggCustomerSecret });
 });
 
 router.post('/login', async (req, res) => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "private": true,
   "engines": {
-    "node": "14.x"
+    "node": ">14.x"
   },
   "dependencies": {
     "@mui/icons-material": "^5.10.3",


### PR DESCRIPTION
# Add option to allow harden client api-key access using customer secret

* Backend side:
  * Read the signing token from `NX_STIGG_SIGNING_TOKEN` environment variable
  * create customer secret using the signing token as `HMAC(<signing-token>, <customer-id>)` and return it to the client
* Client side:
  * provide the customer secret to the `js-client-sdk` when setting the current customer.

The following diagram explains how it will work:
![image](https://user-images.githubusercontent.com/7790205/209861762-546cadd0-a22a-4004-815d-8316a5205368.png)
